### PR TITLE
Feature: provide unicode version in the parser

### DIFF
--- a/ucd-parser/src/input.rs
+++ b/ucd-parser/src/input.rs
@@ -16,6 +16,7 @@ macro_rules! include_ucd {
 #[derive(Clone, Copy)]
 pub enum InputFile {
 	Blocks,
+	ReadMe,
 	UnicodeData,
 }
 
@@ -27,6 +28,7 @@ impl Input {
 	pub fn get(file: InputFile) -> Self {
 		match file {
 			InputFile::Blocks => include_ucd!("Blocks.txt"),
+			InputFile::ReadMe => include_ucd!("ReadMe.txt"),
 			InputFile::UnicodeData => include_ucd!("UnicodeData.txt"),
 		}
 	}
@@ -45,6 +47,11 @@ impl Input {
 			.map(|x| x.trim_end())
 			.filter(|x| x.len() > 0);
 		lines
+	}
+
+	/// Returns the full text for the input trimmed.
+	pub fn text(&self) -> &'static str {
+		self.0.trim()
 	}
 }
 
@@ -79,5 +86,12 @@ mod tests {
 		let input = read_test_input!("comments.in");
 		let input = input.lines().collect::<Vec<_>>();
 		assert_eq!(input, vec!["nc 1", "nc 2", "nc 3", "nc 4"]);
+	}
+
+	#[test]
+	fn can_read_entire_file() {
+		let input = read_test_input!("basic-123.in");
+		let input = input.text();
+		assert_eq!(input, "line 1\nline 2\nline 3");
 	}
 }

--- a/ucd-parser/src/lib.rs
+++ b/ucd-parser/src/lib.rs
@@ -22,3 +22,6 @@ pub use unicode_data::*;
 
 mod data;
 pub use data::*;
+
+mod version;
+pub use version::*;

--- a/ucd-parser/src/version.rs
+++ b/ucd-parser/src/version.rs
@@ -1,0 +1,49 @@
+use once_cell::sync::Lazy;
+
+use crate::input::{Input, InputFile};
+
+pub fn unicode_version() -> &'static str {
+	static VERSION: Lazy<&'static str> = Lazy::new(|| {
+		let file = Input::get(InputFile::ReadMe);
+
+		let mut file = file.text();
+		let version_prefix = "Version ";
+		let mut version = None;
+		while let Some(index) = file.find(version_prefix) {
+			file = &file[index + version_prefix.len()..];
+			if let Some(char) = file.chars().next() {
+				if char.is_ascii_digit() {
+					let end = file
+						.find(|c: char| c != '.' && !c.is_ascii_digit())
+						.unwrap_or(file.len());
+					version = Some(&file[..end]);
+					break;
+				}
+			}
+		}
+		version.unwrap_or_default()
+	});
+	&VERSION
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn should_provide_unicode_version() {
+		let version = unicode_version();
+		assert!(version != "");
+
+		let parts = version.split(".");
+		let parts = parts.collect::<Vec<_>>();
+		assert_eq!(parts.len(), 3);
+
+		let parts = parts
+			.into_iter()
+			.map(|x| x.parse::<u32>().unwrap())
+			.collect::<Vec<_>>();
+
+		assert!(parts[0] >= 14);
+	}
+}


### PR DESCRIPTION
- add `unicode_version` function
- extract version from `ReadMe.txt`

Closes #8 