### PR TITLE
Issue #11 - add generic property ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 
 members = [
-	"ucd-parser"
+	"ucd-parser",
+	"property-ranges"
 ]

--- a/property-ranges/Cargo.toml
+++ b/property-ranges/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "property-ranges"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/property-ranges/src/lib.rs
+++ b/property-ranges/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn it_works() {
+		let result = 2 + 2;
+		assert_eq!(result, 4);
+	}
+}

--- a/property-ranges/src/lib.rs
+++ b/property-ranges/src/lib.rs
@@ -1,2 +1,5 @@
 mod table;
 pub use table::*;
+
+mod ranges;
+pub use ranges::*;

--- a/property-ranges/src/lib.rs
+++ b/property-ranges/src/lib.rs
@@ -1,8 +1,2 @@
-#[cfg(test)]
-mod tests {
-	#[test]
-	fn it_works() {
-		let result = 2 + 2;
-		assert_eq!(result, 4);
-	}
-}
+mod table;
+pub use table::*;

--- a/property-ranges/src/lib.rs
+++ b/property-ranges/src/lib.rs
@@ -1,5 +1,4 @@
 mod table;
 pub use table::*;
 
-mod ranges;
-pub use ranges::*;
+pub mod ranges;

--- a/property-ranges/src/ranges.rs
+++ b/property-ranges/src/ranges.rs
@@ -18,7 +18,7 @@ pub struct CodepointRange<T> {
 /// to set or update the value for each sub-range:
 ///
 /// ```
-/// # use property_ranges::*;
+/// # use property_ranges::ranges::*;
 /// let mut map = CodepointRangeMap::default();
 /// map.set(0, 5, |v| *v = 100); // `v` starts as zero
 /// map.set(3, 9, |v| *v += 25); // `v` is 100 for the existing `3..=5` range

--- a/property-ranges/src/ranges.rs
+++ b/property-ranges/src/ranges.rs
@@ -1,0 +1,347 @@
+#[derive(Clone)]
+pub struct CodepointRange<T> {
+	pub first: u32,
+	pub last: u32,
+	pub value: T,
+}
+
+pub struct CodepointRangeMap<T: Default + Clone> {
+	ranges: Vec<CodepointRange<T>>,
+}
+
+impl<T: Default + Clone> CodepointRangeMap<T> {
+	pub fn count(&self) -> usize {
+		self.ranges.len()
+	}
+
+	pub fn set<Fn: FnMut(&mut T)>(&mut self, mut first: u32, last: u32, mut updater: Fn) {
+		if last < first {
+			panic!("CodepointRangeMap: invalid range (last < first)");
+		}
+
+		let mut new_entries = Vec::new();
+		for range in self.ranges.iter_mut() {
+			if first < range.first {
+				let mut value = T::default();
+				updater(&mut value);
+
+				let last = std::cmp::min(range.first - 1, last);
+				new_entries.push(CodepointRange { first, last, value });
+				first = range.first;
+			}
+
+			if first <= range.last && last >= range.first {
+				if first > range.first {
+					let mut head = range.clone();
+					head.last = first - 1;
+					new_entries.push(head);
+					range.first = first;
+				}
+				first = range.last + 1;
+
+				if last < range.last {
+					let mut tail = range.clone();
+					tail.first = last + 1;
+					new_entries.push(tail);
+					range.last = last;
+				}
+
+				updater(&mut range.value);
+			}
+
+			if first > last {
+				break;
+			}
+		}
+		if first <= last {
+			let mut value = T::default();
+			updater(&mut value);
+			new_entries.push(CodepointRange { first, last, value });
+		}
+		self.ranges.append(&mut new_entries);
+		self.ranges.sort_by_key(|x| x.first);
+	}
+
+	pub fn get(&self, index: usize) -> &CodepointRange<T> {
+		&self.ranges[index]
+	}
+}
+
+impl<T: Default + Clone> Default for CodepointRangeMap<T> {
+	fn default() -> Self {
+		CodepointRangeMap {
+			ranges: Default::default(),
+		}
+	}
+}
+
+#[cfg(test)]
+mod test_codepoint_map {
+	use super::*;
+
+	#[test]
+	fn default_is_empty() {
+		let map: CodepointRangeMap<()> = Default::default();
+		assert_eq!(map.count(), 0);
+	}
+
+	#[test]
+	#[should_panic = "invalid range"]
+	fn add_invalid_range_panics() {
+		let mut map: CodepointRangeMap<()> = Default::default();
+		map.set(20, 19, |_| {});
+	}
+
+	macro_rules! check_map {
+		($($tokens:tt)*) => {
+			let mut map = CodepointRangeMap::default();
+			_check_map_body!(map, $($tokens)*)
+		};
+	}
+
+	macro_rules! _check_map_body {
+		($map:ident, ) => {};
+
+		($map:ident, set $first:literal .. $last:literal = $value:literal $($tail:tt)*) => {
+			$map.set($first, $last, |v: &mut String| *v = $value.to_string());
+			_check_map_body!($map, $($tail)*)
+		};
+
+		($map:ident, add $first:literal .. $last:literal = $value:literal $($tail:tt)*) => {
+			$map.set($first, $last, |v: &mut String| v.push_str($value));
+			_check_map_body!($map, $($tail)*)
+		};
+
+		($map:ident, check count $count:literal $($tail:tt)*) => {
+			let count = $map.count();
+			if count != $count {
+				panic!("expected {} range{}, it was {}", $count, if $count != 1 { "s" } else { "" }, count);
+			}
+			_check_map_body!($map, $($tail)*)
+		};
+
+		($map:ident, check $index:literal : $first:literal .. $last:literal = $value:literal $($tail:tt)*) => {
+			let header = concat!("checking #", $index);
+			if $index >= $map.count() {
+				panic!("{}: index out of range", header);
+			}
+			let row = $map.get($index);
+			if (row.first != $first || row.last != $last) {
+				panic!("{}: expected range `{}..{}`, it was `{}..{}`", header, $first, $last, row.first, row.last);
+			}
+
+			if (row.value != $value) {
+				panic!("{}: expected `{}..{}` = `{}`, it was `{}`", header, $first, $last, $value, row.value);
+			}
+			_check_map_body!($map, $($tail)*)
+		};
+	}
+
+	#[test]
+	fn can_insert_a_single_range() {
+		check_map!(
+			set 0..10 = "some range"
+			check count 1
+			check 0: 0..10 = "some range"
+		);
+
+		check_map!(
+			set 10..20 = "other range"
+			check count 1
+			check 0: 10..20 = "other range"
+		);
+	}
+
+	#[test]
+	fn can_insert_multiple_ranges() {
+		check_map!(
+			set 10..20 = "a"
+			set 30..40 = "b"
+			check count 2
+			check 0: 10..20 = "a"
+			check 1: 30..40 = "b"
+		);
+	}
+
+	#[test]
+	fn can_modify_a_range() {
+		check_map!(
+			set 10..20 = "a"
+			add 10..20 = "b"
+			check count 1
+			check 0: 10..20 = "ab"
+		);
+
+		check_map!(
+			set 10..20 = "a"
+			set 30..40 = "b"
+			add 30..40 = "c"
+			check count 2
+			check 0: 10..20 = "a"
+			check 1: 30..40 = "bc"
+		);
+	}
+
+	#[test]
+	fn set_passes_current_value_for_range() {
+		let mut map = CodepointRangeMap::default();
+		map.set(0, 10, |v| {
+			assert_eq!(v, &0);
+			*v = 100;
+		});
+
+		map.set(0, 10, |v| {
+			assert_eq!(v, &100);
+		});
+	}
+
+	#[test]
+	fn ranges_are_sorted() {
+		check_map!(
+			set 40..49 = "4"
+			set 10..19 = "1"
+			set 90..99 = "9"
+			set 60..69 = "6"
+			set 70..79 = "7"
+			set 80..89 = "8"
+			set 30..39 = "3"
+			set 20..29 = "2"
+			set 50..59 = "5"
+			check count 9
+			check 0: 10..19 = "1"
+			check 1: 20..29 = "2"
+			check 2: 30..39 = "3"
+			check 3: 40..49 = "4"
+			check 4: 50..59 = "5"
+			check 5: 60..69 = "6"
+			check 6: 70..79 = "7"
+			check 7: 80..89 = "8"
+			check 8: 90..99 = "9"
+		);
+	}
+
+	#[test]
+	fn set_split_ranges_on_overlap() {
+		// single overlap - start
+		check_map!(
+			set 10..50 = "a"
+			add 10..20 = "b"
+			check count 2
+			check 0: 10..20 = "ab"
+			check 1: 21..50 = "a"
+		);
+
+		// single overlap - end
+		check_map!(
+			set 10..50 = "a"
+			add 20..50 = "b"
+			check count 2
+			check 0: 10..19 = "a"
+			check 1: 20..50 = "ab"
+		);
+
+		// single overlap - middle
+		check_map!(
+			set 10..50 = "a"
+			add 20..30 = "b"
+			check count 3
+			check 0: 10..19 = "a"
+			check 1: 20..30 = "ab"
+			check 2: 31..50 = "a"
+		);
+
+		// double overlap
+		check_map!(
+			set 10..29 = "a"
+			set 30..50 = "b"
+			add 20..40 = "c"
+			check count 4
+			check 0: 10..19 = "a"
+			check 1: 20..29 = "ac"
+			check 2: 30..40 = "bc"
+			check 3: 41..50 = "b"
+		);
+
+		// triple overlap - full
+		check_map!(
+			set 10..19 = "a"
+			set 20..29 = "b"
+			set 30..39 = "c"
+			add 10..39 = "d"
+			check count 3
+			check 0: 10..19 = "ad"
+			check 1: 20..29 = "bd"
+			check 2: 30..39 = "cd"
+		);
+
+		// triple overlap - contained
+		check_map!(
+			set 20..29 = "a"
+			set 30..39 = "b"
+			set 40..49 = "c"
+			add 10..60 = "d"
+			check count 5
+			check 0: 10..19 = "d"
+			check 1: 20..29 = "ad"
+			check 2: 30..39 = "bd"
+			check 3: 40..49 = "cd"
+			check 4: 50..60 = "d"
+		);
+
+		// triple overlap - start
+		check_map!(
+			set 10..19 = "a"
+			set 20..29 = "b"
+			set 30..39 = "c"
+			add 10..35 = "d"
+			check count 4
+			check 0: 10..19 = "ad"
+			check 1: 20..29 = "bd"
+			check 2: 30..35 = "cd"
+			check 3: 36..39 = "c"
+		);
+
+		// triple overlap - end
+		check_map!(
+			set 10..19 = "a"
+			set 20..29 = "b"
+			set 30..39 = "c"
+			add 15..39 = "d"
+			check count 4
+			check 0: 10..14 = "a"
+			check 1: 15..19 = "ad"
+			check 2: 20..29 = "bd"
+			check 3: 30..39 = "cd"
+		);
+
+		// triple overlap - middle
+		check_map!(
+			set 10..19 = "a"
+			set 20..29 = "b"
+			set 30..39 = "c"
+			add 15..35 = "d"
+			check count 5
+			check 0: 10..14 = "a"
+			check 1: 15..19 = "ad"
+			check 2: 20..29 = "bd"
+			check 3: 30..35 = "cd"
+			check 4: 36..39 = "c"
+		);
+
+		// triple overlap - spaced
+		check_map!(
+			set 20..30 = "a"
+			set 40..50 = "b"
+			set 60..70 = "c"
+			add 10..80 = "d"
+			check count 7
+			check 0: 10..19 = "d"
+			check 1: 20..30 = "ad"
+			check 2: 31..39 = "d"
+			check 3: 40..50 = "bd"
+			check 4: 51..59 = "d"
+			check 5: 60..70 = "cd"
+			check 6: 71..80 = "d"
+		);
+	}
+}

--- a/property-ranges/src/table.rs
+++ b/property-ranges/src/table.rs
@@ -42,6 +42,11 @@ impl PropertyTable {
 			if it.range == range {
 				it.values.push((key.as_any(), T::value_to_any(property)));
 				return;
+			} else if *it.range.end() + 1 == *range.start() {
+				if it.get(key.clone()) == Some(property.clone()) && it.values.len() == 1 {
+					it.range = RangeInclusive::new(*it.range.start(), *range.end());
+					return;
+				}
 			}
 		}
 		let mut range = PropertyRange::new(range);
@@ -86,7 +91,7 @@ impl PropertyRange {
 pub struct PropertyValue<T>(pub RangeInclusive<u32>, pub T);
 
 pub trait PropertyKey: PartialEq + Clone + 'static {
-	type Value: Clone;
+	type Value: Clone + PartialEq;
 
 	fn as_any(&self) -> Box<dyn Any> {
 		Box::new(self.clone())
@@ -159,22 +164,22 @@ mod tests {
 		assert_eq!(table_a.count(), 255);
 		assert_eq!(table_a.count_ranges(), 1);
 
-		let range_a = table_a.get_range(0);
-		assert_eq!(range_a.range, 1..=255);
-		assert_eq!(range_a.get(SomeKeyA), Some("some property"));
+		let row_a = table_a.get_range(0);
+		assert_eq!(row_a.range, 1..=255);
+		assert_eq!(row_a.get(SomeKeyA), Some("some property"));
 
 		let mut table_b = PropertyTable::new();
 		table_b.set_range(0..=9, SomeKeyB, 42);
 		assert_eq!(table_b.count(), 10);
 		assert_eq!(table_b.count_ranges(), 1);
 
-		let range_b = table_b.get_range(0);
-		assert_eq!(range_b.range, 0..=9);
-		assert_eq!(range_b.get(SomeKeyB), Some(42));
+		let row_b = table_b.get_range(0);
+		assert_eq!(row_b.range, 0..=9);
+		assert_eq!(row_b.get(SomeKeyB), Some(42));
 	}
 
 	#[test]
-	fn stores_multiple_properties() {
+	fn stores_multiple_properties_per_range() {
 		#[derive(Clone, PartialEq)]
 		struct Key(&'static str);
 
@@ -186,9 +191,9 @@ mod tests {
 		table.set_range(0..=9, Key("a"), "value a");
 		table.set_range(0..=9, Key("b"), "value b");
 
-		let range = table.get_range(0);
-		assert_eq!(range.get(Key("a")), Some("value a"));
-		assert_eq!(range.get(Key("b")), Some("value b"));
+		let row = table.get_range(0);
+		assert_eq!(row.get(Key("a")), Some("value a"));
+		assert_eq!(row.get(Key("b")), Some("value b"));
 	}
 
 	#[test]
@@ -202,15 +207,15 @@ mod tests {
 
 		let mut table = PropertyTable::new();
 		table.set_range(10..=19, Key, 1);
-		table.set_range(20..=29, Key, 2);
+		table.set_range(30..=39, Key, 3);
 		assert_eq!(table.count_ranges(), 2);
 
 		let a = table.get_range(0);
 		let b = table.get_range(1);
 		assert_eq!(a.range, 10..=19);
-		assert_eq!(b.range, 20..=29);
+		assert_eq!(b.range, 30..=39);
 		assert_eq!(a.get(Key), Some(1));
-		assert_eq!(b.get(Key), Some(2));
+		assert_eq!(b.get(Key), Some(3));
 	}
 
 	#[test]
@@ -237,5 +242,90 @@ mod tests {
 		table.set_range(0..10, "key", 0);
 
 		assert_eq!(table.get_range(0).get("other key"), None);
+	}
+
+	#[derive(Clone, PartialEq)]
+	struct Key(&'static str);
+
+	impl PropertyKey for Key {
+		type Value = u32;
+	}
+
+	macro_rules! _check_table_body {
+		($tb:ident, ) => {};
+
+		($tb:ident, set $range:expr => $key:literal = $val:expr, $($tail:tt)*) => {
+			$tb.set_range($range, Key($key), $val);
+			_check_table_body!($tb, $($tail)*)
+		};
+
+		($tb:ident, check $count:literal ranges, $($tail:tt)*) => {
+			let range_count = $tb.count_ranges();
+			assert_eq!(range_count, $count,
+				concat!("expected ", $count, " range{}, was {}"),
+				if $count != 1 { "s" } else { "" }, range_count);
+			_check_table_body!($tb, $($tail)*)
+		};
+
+		($tb:ident, check $count:literal range, $($tail:tt)*) => {
+			_check_table_body!($tb, check $count ranges, $($tail)*)
+		};
+
+		($tb:ident, check $index:literal as $range:expr => {
+			$($key:literal = $val:expr),*
+		} $($tail:tt)*) => {
+			let header = concat!("checking range at ", $index);
+			if $index >= $tb.count_ranges() {
+				panic!("{}: no such range", header);
+			}
+			let row = $tb.get_range($index);
+			assert_eq!(row.range, $range,
+				"{}: expected range `{:?}`", header, $range);
+			$(
+				let actual_val = row.get(Key($key));
+				let expected = $val;
+				assert_eq!(actual_val, expected,
+					"{}: expected `{}` = `{:?}`, was `{:?}`",
+					header, $key, expected, actual_val);
+			)*
+			_check_table_body!($tb, $($tail)*)
+		};
+	}
+
+	macro_rules! check_table {
+		($($tokens:tt)*) => {
+			let mut table = PropertyTable::new();
+			_check_table_body!(table, $($tokens)*)
+		};
+	}
+
+	#[test]
+	fn merges_consecutive_ranges_with_same_properties() {
+		check_table!(
+			set 0..10  => "a" = 10,
+			set 10..20 => "a" = 10,
+			check 1 range,
+			check 0 as 0..=19 => { "a" = Some(10) }
+		);
+	}
+
+	#[test]
+	fn does_not_merge_consecutive_ranges_with_different_values() {
+		check_table!(
+			set 0..10  => "a" = 10,
+			set 10..20 => "a" = 20,
+			check 2 ranges,
+			check 0 as 0..=9   => { "a" = Some(10) }
+			check 1 as 10..=19 => { "a" = Some(20) }
+		);
+
+		check_table!(
+			set 0..10  => "a" = 10,
+			set 0..10  => "b" = 20,
+			set 10..20 => "a" = 10,
+			check 2 ranges,
+			check 0 as 0..=9   => { "a" = Some(10), "b" = Some(20) }
+			check 1 as 10..=19 => { "a" = Some(10), "b" = None }
+		);
 	}
 }

--- a/property-ranges/src/table.rs
+++ b/property-ranges/src/table.rs
@@ -3,7 +3,7 @@ use std::{
 	ops::{Range, RangeInclusive},
 };
 
-use crate::CodepointRangeMap;
+use crate::ranges::CodepointRangeMap;
 
 /// Provides a data structure that can map arbitrary property values for
 /// unicode ranges of `u32` codepoints.

--- a/property-ranges/src/table.rs
+++ b/property-ranges/src/table.rs
@@ -1,16 +1,22 @@
-use std::ops::{Range, RangeInclusive};
+use std::{
+	any::Any,
+	ops::{Range, RangeInclusive},
+};
 
 pub struct PropertyTable {
-	range: Option<RangeInclusive<u32>>,
+	ranges: Vec<PropertyRange>,
 }
 
 impl PropertyTable {
 	pub fn new() -> Self {
-		PropertyTable { range: None }
+		PropertyTable {
+			ranges: Default::default(),
+		}
 	}
 
 	pub fn count(&self) -> usize {
-		if let Some(range) = &self.range {
+		if let Some(row) = self.ranges.iter().next() {
+			let range = &row.range;
 			(range.end() - range.start()) as usize + 1
 		} else {
 			0
@@ -18,20 +24,29 @@ impl PropertyTable {
 	}
 
 	pub fn count_ranges(&self) -> usize {
-		1
+		self.ranges.len()
 	}
 
-	pub fn get_range<T: PropertyKey>(&self, _index: usize, _key: T) -> PropertyValue<T::Value> {
-		PropertyValue(self.range.as_ref().unwrap().clone(), T::Value::get_some())
+	pub fn get_range(&self, index: usize) -> &PropertyRange {
+		&self.ranges[index]
 	}
 
 	pub fn set_range<R: CodeRange, T: PropertyKey>(
 		&mut self,
 		range: R,
-		_key: T,
-		_property: T::Value,
+		key: T,
+		property: T::Value,
 	) {
-		self.range = Some(RangeInclusive::new(range.start(), range.end_inclusive()));
+		let range = RangeInclusive::new(range.start(), range.end_inclusive());
+		for it in self.ranges.iter_mut() {
+			if it.range == range {
+				it.values.push((key.as_any(), T::value_to_any(property)));
+				return;
+			}
+		}
+		let mut range = PropertyRange::new(range);
+		range.values.push((key.as_any(), T::value_to_any(property)));
+		self.ranges.push(range);
 	}
 }
 
@@ -41,26 +56,44 @@ impl Default for PropertyTable {
 	}
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct PropertyValue<T>(pub RangeInclusive<u32>, pub T);
-
-pub trait PropertyKey {
-	type Value: SomeValue;
+pub struct PropertyRange {
+	pub range: RangeInclusive<u32>,
+	values: Vec<(Box<dyn Any>, Box<dyn Any>)>,
 }
 
-pub trait SomeValue {
-	fn get_some() -> Self;
-}
+impl PropertyRange {
+	pub(crate) fn new(range: RangeInclusive<u32>) -> Self {
+		PropertyRange {
+			range,
+			values: Default::default(),
+		}
+	}
 
-impl SomeValue for u32 {
-	fn get_some() -> Self {
-		42
+	pub fn get<T: PropertyKey + 'static>(&self, key: T) -> T::Value {
+		for (my_key, val) in self.values.iter() {
+			if let Some(my_key) = my_key.downcast_ref::<T>() {
+				if &key == my_key {
+					let val = val.downcast_ref::<T::Value>();
+					return val.unwrap().clone();
+				}
+			}
+		}
+		panic!()
 	}
 }
 
-impl SomeValue for &'static str {
-	fn get_some() -> Self {
-		"some property"
+#[derive(Debug, PartialEq, Eq)]
+pub struct PropertyValue<T>(pub RangeInclusive<u32>, pub T);
+
+pub trait PropertyKey: PartialEq + Clone + 'static {
+	type Value: Clone;
+
+	fn as_any(&self) -> Box<dyn Any> {
+		Box::new(self.clone())
+	}
+
+	fn value_to_any(value: Self::Value) -> Box<dyn Any> {
+		Box::new(value)
 	}
 }
 
@@ -106,13 +139,15 @@ mod tests {
 	}
 
 	#[test]
-	fn can_store_single_range_with_single_property() {
+	fn stores_single_range_with_single_property() {
+		#[derive(Clone, PartialEq)]
 		struct SomeKeyA;
 
 		impl PropertyKey for SomeKeyA {
 			type Value = &'static str;
 		}
 
+		#[derive(Clone, PartialEq)]
 		struct SomeKeyB;
 
 		impl PropertyKey for SomeKeyB {
@@ -123,20 +158,64 @@ mod tests {
 		table_a.set_range(1..=255, SomeKeyA, "some property");
 		assert_eq!(table_a.count(), 255);
 		assert_eq!(table_a.count_ranges(), 1);
-		assert_eq!(
-			table_a.get_range(0, SomeKeyA),
-			PropertyValue(1..=255, "some property")
-		);
+
+		let range_a = table_a.get_range(0);
+		assert_eq!(range_a.range, 1..=255);
+		assert_eq!(range_a.get(SomeKeyA), "some property");
 
 		let mut table_b = PropertyTable::new();
 		table_b.set_range(0..=9, SomeKeyB, 42);
 		assert_eq!(table_b.count(), 10);
 		assert_eq!(table_b.count_ranges(), 1);
-		assert_eq!(table_b.get_range(0, SomeKeyB), PropertyValue(0..=9, 42u32));
+
+		let range_b = table_b.get_range(0);
+		assert_eq!(range_b.range, 0..=9);
+		assert_eq!(range_b.get(SomeKeyB), 42u32);
+	}
+
+	#[test]
+	fn stores_multiple_properties() {
+		#[derive(Clone, PartialEq)]
+		struct Key(&'static str);
+
+		impl PropertyKey for Key {
+			type Value = &'static str;
+		}
+
+		let mut table = PropertyTable::new();
+		table.set_range(0..=9, Key("a"), "value a");
+		table.set_range(0..=9, Key("b"), "value b");
+
+		let range = table.get_range(0);
+		assert_eq!(range.get(Key("a")), "value a");
+		assert_eq!(range.get(Key("b")), "value b");
+	}
+
+	#[test]
+	fn stores_multiple_ranges() {
+		#[derive(Clone, PartialEq)]
+		struct Key;
+
+		impl PropertyKey for Key {
+			type Value = u32;
+		}
+
+		let mut table = PropertyTable::new();
+		table.set_range(10..=19, Key, 1);
+		table.set_range(20..=29, Key, 2);
+		assert_eq!(table.count_ranges(), 2);
+
+		let a = table.get_range(0);
+		let b = table.get_range(1);
+		assert_eq!(a.range, 10..=19);
+		assert_eq!(b.range, 20..=29);
+		assert_eq!(a.get(Key), 1);
+		assert_eq!(b.get(Key), 2);
 	}
 
 	#[test]
 	fn supports_non_inclusive_range() {
+		#[derive(Clone, PartialEq)]
 		struct Key;
 
 		impl PropertyKey for Key {
@@ -145,6 +224,6 @@ mod tests {
 
 		let mut table = PropertyTable::new();
 		table.set_range(0..10, Key, 42);
-		assert_eq!(table.get_range(0, Key), PropertyValue(0..=9, 42));
+		assert_eq!(table.get_range(0).range, 0..=9);
 	}
 }

--- a/property-ranges/src/table.rs
+++ b/property-ranges/src/table.rs
@@ -1,0 +1,112 @@
+use std::ops::RangeInclusive;
+
+pub struct PropertyTable {
+	range: Option<RangeInclusive<u32>>,
+}
+
+impl PropertyTable {
+	pub fn new() -> Self {
+		PropertyTable { range: None }
+	}
+
+	pub fn count(&self) -> usize {
+		if let Some(range) = &self.range {
+			(range.end() - range.start()) as usize + 1
+		} else {
+			0
+		}
+	}
+
+	pub fn count_ranges(&self) -> usize {
+		1
+	}
+
+	pub fn get_range<T: PropertyKey>(&self, _index: usize, _key: T) -> PropertyValue<T::Value> {
+		PropertyValue(self.range.as_ref().unwrap().clone(), T::Value::get_some())
+	}
+
+	pub fn set_range<T: PropertyKey>(
+		&mut self,
+		range: RangeInclusive<u32>,
+		_key: T,
+		_property: T::Value,
+	) {
+		self.range = Some(range);
+	}
+}
+
+impl Default for PropertyTable {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PropertyValue<T>(pub RangeInclusive<u32>, pub T);
+
+pub trait PropertyKey {
+	type Value: SomeValue;
+}
+
+pub trait SomeValue {
+	fn get_some() -> Self;
+}
+
+impl SomeValue for u32 {
+	fn get_some() -> Self {
+		42
+	}
+}
+
+impl SomeValue for &'static str {
+	fn get_some() -> Self {
+		"some property"
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn can_create_empty() {
+		let empty = PropertyTable::new();
+		assert_eq!(empty.count(), 0);
+	}
+
+	#[test]
+	fn supports_default() {
+		let empty: PropertyTable = Default::default();
+		assert_eq!(empty.count(), 0);
+	}
+
+	#[test]
+	fn can_store_single_range_with_single_property() {
+		struct SomeKeyA;
+
+		impl PropertyKey for SomeKeyA {
+			type Value = &'static str;
+		}
+
+		struct SomeKeyB;
+
+		impl PropertyKey for SomeKeyB {
+			type Value = u32;
+		}
+
+		let mut table_a = PropertyTable::new();
+		table_a.set_range(1..=255, SomeKeyA, "some property");
+		assert_eq!(table_a.count(), 255);
+		assert_eq!(table_a.count_ranges(), 1);
+		assert_eq!(
+			table_a.get_range(0, SomeKeyA),
+			PropertyValue(1..=255, "some property")
+		);
+
+		let mut table_b = PropertyTable::new();
+		table_b.set_range(0..=9, SomeKeyB, 42);
+		assert_eq!(table_b.count(), 10);
+		assert_eq!(table_b.count_ranges(), 1);
+		assert_eq!(table_b.get_range(0, SomeKeyB), PropertyValue(0..=9, 42u32));
+	}
+}

--- a/ucd-parser/Cargo.toml
+++ b/ucd-parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ucd-parser"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Add a new `property-ranges` crate providing a generic property table to be used to associate Unicode properties to ranges of `u32` codepoints.

The main type of this crate is `RangeTable`, which provides a container that maps arbitrary properties to ranges.

Closes #11 